### PR TITLE
Add Button to List Mounted Auth Backends

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -27,6 +27,14 @@
     <label for="key">Key:</label>
     <input type="text" id="key" value="">
     <button id="unsealButton" type=button >unseal</button><br>
+
+    <br><br>
+
+    <button id="getAuthsMethodsButton" type=button >get auth methods</button><br>
+    <label for="authMethods">Mounted Auth Methods:</label>
+    <p id="authMethods"></p>
+
+
   </body>
   <script>window.$ = window.jQuery = require('../node_modules/jquery/dist/jquery.min.js');</script>
   <script src="js/index.js"></script>

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -20,6 +20,8 @@ $(function() {
   $("#setTokenButton").click(function() {
     vault.token =  $("#token").val();
   })
+
+  $("#getAuthsMethodsButton").click(getMountedAuthBackends);
 });
 
 function updateSealStatus(newStatus) {
@@ -47,4 +49,12 @@ function initVault(serverAddress) {
     endpoint: serverAddress
   };
   vault = require("node-vault")(options);
+}
+
+function getMountedAuthBackends() {
+  vault.auths()
+    .then(function(result) {
+        $("#authMethods").text(Object.keys(result));
+    })
+    .catch((err) => console.error(err));
 }


### PR DESCRIPTION
Super simple (and dirty) implementation of UI for `vault.auths()`.
Requires that the user have a valid token to authenticate with.
Doesn't include any sort of error handling except for console.log.

Also, requires the vault to be unsealed. Fails silently otherwise.
