### PR TITLE
Add Authentication Status to Navbar

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -15,6 +15,8 @@
       <li>
         <label for="isConnected">Is Connected?:</label>
         <label id="isConnected"></label>
+        <label for="isAuthenticated">Is Authenticated?:</label>
+        <label id="isAuthenticated"></label>
         <label for="status">Is Sealed?:</label>
         <label id="status"></label>
       </li>

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -11,12 +11,20 @@ $(function() {
 
   $("#unsealButton").click(unseal);
 
-  $("#setTokenButton").click(function() {
-    vault.token =  $("#token").val();
-  });
+  $("#setTokenButton").click(authenticate);
 
   $("#getAuthsMethodsButton").click(getMountedAuthBackends);
 });
+
+function authenticate() {
+  var token =  $("#token").val();
+  setAuthenticationToken(token);
+  updateStatus();
+}
+
+function setAuthenticationToken(token) {
+  vault.token = token;
+}
 
 function connectToServer() {
   var serverAddress = $("#serverAddress").val();
@@ -35,7 +43,12 @@ function updateStatus() {
       document.getElementById("threshold").innerHTML = result.t;
       document.getElementById("status").innerHTML = result.sealed;
       document.getElementById("isConnected").innerHTML = true;
+      document.getElementById("isAuthenticated").innerHTML = isAuthenticated();
     });
+}
+
+function isAuthenticated() {
+  return vault.token !== undefined
 }
 
 function unseal() {


### PR DESCRIPTION
This is the simplest implementation of authentication status imaginable.
At the moment, this status ONLY indicates whether the vault client thinks it's authenticated,
meaning whether or not the instance of node-vault has a `token` property that is not `undefined`.
This is the MVP, in the future this will get much more advanced but is mostly correct right now
because we only allow authentication via the root token.

![capture](https://cloud.githubusercontent.com/assets/4032410/18599829/693b5d44-7c28-11e6-9d02-6c761f9ae91b.PNG)
