### PR TITLE
Rename Authentication Accordian to 'Set Authentication Token'

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -49,10 +49,10 @@
         <div class="panel panel-default">
           <div class="panel-heading">
             <h4 class="panel-title">
-              <a data-toggle="collapse" href="#authenticationCollapse">Authenticate</a>
+              <a data-toggle="collapse" href="#authenticationTokenCollapse">Set Authentication Token</a>
             </h4>
           </div>
-          <div id="authenticationCollapse" class="panel-collapse collapse">
+          <div id="authenticationTokenCollapse" class="panel-collapse collapse">
             <div class="panel-body">
               <label for="token">Token:</label>
               <input type="text" id="token">

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -11,14 +11,14 @@ $(function() {
 
   $("#unsealButton").click(unseal);
 
-  $("#setTokenButton").click(authenticate);
+  $("#setTokenButton").click(setAuthenticationTokenHandler);
 
   $("#getAuthsMethodsButton").click(getMountedAuthBackends);
 
   $("#sealButton").click(seal);
 });
 
-function authenticate() {
+function setAuthenticationTokenHandler() {
   var token =  $("#token").val();
   setAuthenticationToken(token);
   updateStatus();


### PR DESCRIPTION
Authentication wasn't a good name here because setting an authentication token is something you can only do once you're authenticated.
This naming more accurately describes what is going on.

![capture](https://cloud.githubusercontent.com/assets/4032410/18600877/eeea5832-7c2d-11e6-9ef0-f24f45161145.PNG)
