### PR TITLE
Add Read Secrets Functionality

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -170,9 +170,13 @@
             </h4>
           </div>
           <div id="readCollapse" class="panel-collapse collapse">
-
+            <div class="panel-body">
+                <label for="mountPoint">Mount Point:</label>
+                <input type="text" id="mountPoint">
+                <p id="secrets"></p>
+            </div>
             <div class="panel-footer">
-
+              <button class="btn btn-primary" id="readSecretsButton">Read Secrets</button><br>
             </div>
           </div>
         </div>

--- a/app/js/index.js
+++ b/app/js/index.js
@@ -6,20 +6,14 @@ $(function() {
     connectToServer();
     updateStatus();
   });
-
   $("#getStatus").click(updateStatus);
-
   $("#unsealButton").click(unseal);
-
   $("#setTokenButton").click(setAuthenticationTokenHandler);
-
   $("#getAuthsMethodsButton").click(getMountedAuthBackends);
-
   $("#sealButton").click(seal);
-
   $("#userpassButton").click(userpassAuthenticate);
-
   $("#githubButton").click(githubAuthenticate);
+  $("#readSecretsButton").click(readSecrets);
 });
 
 function setAuthenticationTokenHandler() {
@@ -106,4 +100,23 @@ function githubAuthenticate() {
   vault.githubLogin({ token })
     .then((result) => setAuthenticationToken(result.auth.client_token))
     .then(updateStatus);
+}
+
+function readSecrets() {
+  vault.read($("#mountPoint").val())
+    .then((result) => successfulSecretQueryHandler(result.data))
+    .catch((result) => failedSecretQueryHandler(result));
+}
+
+function successfulSecretQueryHandler(dictionary) {
+  $("#secrets").text(formatSecrets(dictionary));
+}
+
+function failedSecretQueryHandler(result) {
+  $("#secrets").text(result);
+}
+
+function formatSecrets(dictionary) {
+  var output = JSON.stringify(dictionary, null, 4);
+  return output;
 }


### PR DESCRIPTION
Adds ability to read secrets. The user suplies a path the the mounted secret backend, for instance 'secret/foo'.
Upon submitting, the connected vault will be queried and the result printed.