### PR TITLE
Hide userpass Passwords

### DIFF
--- a/app/js/components/UserPassAuthentication.jsx
+++ b/app/js/components/UserPassAuthentication.jsx
@@ -33,7 +33,8 @@ class UserPassAuthentication extends React.Component {
           <TextField
             floatingLabelText="Password"
             value={this.state.password}
-            onChange={this.handlePasswordChange}/>
+            onChange={this.handlePasswordChange}
+            type="password"/>
           <RaisedButton
             type="submit"
             label="Connect"


### PR DESCRIPTION
Adds the `password` type to the password field in ordor to hide obfuscate entered text.