### PR TITLE
Add read secrets functionality

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,7 +5,7 @@ const BrowserWindow = electron.BrowserWindow
 let mainWindow
 
 function createWindow () {
-  mainWindow = new BrowserWindow({width: 800, height: 600})
+  mainWindow = new BrowserWindow({width: 1000, height: 1000})
 
   mainWindow.loadURL('file://' + __dirname + '/app/index.html')
 

--- a/app/js/components/Secrets.jsx
+++ b/app/js/components/Secrets.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import TextField from 'material-ui/TextField';
+import RaisedButton from 'material-ui/RaisedButton';
+
+class Secrets extends React.Component {
+  state = {
+    mountPoint: '',
+    secrets: ''
+  }
+
+  handleChange = (event) => {
+    this.setState({mountPoint: event.target.value});
+  };
+
+  handleSubmit = (event) => {
+    this.props.getSecrets(this.state.mountPoint)
+      .then((result) => {
+        this.setState({secrets: JSON.stringify(result.data, null, 4)});
+      })
+      .catch((err) => {
+        this.setState({secrets: err.toString()});
+      });
+    event.preventDefault();
+  };
+
+  render() {
+    return (
+      <div>
+        <h2>Read Secrets:</h2>
+        <form onSubmit={this.handleSubmit}>
+          <TextField
+            floatingLabelText="Mount Point"
+            hintText="secret/"
+            value={this.state.mountPoint}
+            onChange={this.handleChange}/>
+          <RaisedButton
+            type="submit"
+            label="Read"
+            primary={true}/>
+        </form>
+        <pre>
+          <code>
+            {this.state.secrets}
+          </code>
+        </pre>
+      </div>
+    );
+  }
+}
+
+export default Secrets;

--- a/app/js/containers/Page.jsx
+++ b/app/js/containers/Page.jsx
@@ -5,6 +5,7 @@ import Authentication from '../components/Authentication';
 import ConnectionForm from '../components/ConnectionForm';
 import Mounts from '../components/Mounts';
 import NavBar from '../components/NavBar';
+import Secrets from '../components/Secrets';
 import Unseal from '../components/Unseal';
 
 class Page extends React.Component {
@@ -92,6 +93,10 @@ class Page extends React.Component {
     return this.state.vault.auths();
   }
 
+  getSecrets = (mountPoint) => {
+    return this.state.vault.read(mountPoint);
+  }
+
   render = () => {
     let visibleElement = null;
 
@@ -119,10 +124,14 @@ class Page extends React.Component {
       );
     } else {
       visibleElement = (
-        <Mounts
-          getAuths={this.getAuths}
-          getMounts={this.getMounts}
-         />
+        <div>
+          <Mounts
+            getAuths={this.getAuths}
+            getMounts={this.getMounts}
+           />
+          <Secrets
+            getSecrets={this.getSecrets}/>
+        </div>
       );
     }
     return (


### PR DESCRIPTION
Adds UI for reading secrets for a provided mount point.
For instance, if a value is strored at `secret/password`, enter that
into the mount point field and the respective value will be returned.

FYI the CLI for writing a secret is:
```
$ vault write secret/password \
    value=itsasecret
```

Also increases the default window size to 1000x1000.