### PR TITLE
Improve Interact Section By Adding A Navigation Menu

### DIFF
--- a/app/js/components/Interact.jsx
+++ b/app/js/components/Interact.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+
+import Menu from 'material-ui/Menu';
+import MenuItem from 'material-ui/MenuItem';
+import Paper from 'material-ui/Paper';
+
+import Mounts from '../components/Mounts';
+import Secrets from '../components/Secrets';
+
+const styles = {
+  content:{
+    height: '100%',
+    margin: '0 0 0 5px',
+    flex: 4
+  },
+  menu:{
+    height: '100%'
+  },
+  selectedMenuItem: {
+    backgroundColor: '#00BCD4', //cyan500
+    color: 'white'
+  },
+  wrapper:{
+    display: 'flex',
+    flexDirection: 'row wrap',
+    width: '100%'
+  }
+};
+
+export default class Interact extends React.Component {
+  state = {
+    selectedElement: 0
+  };
+
+  handleChange = (event, value) => {
+    this.setState({selectedElement: value});
+  };
+
+  render = () => {
+    let visibleElement = null;
+
+    switch (this.state.selectedElement) {
+      case 0:
+        visibleElement = <Mounts {...this.props} />;
+        break;
+      case 1:
+        visibleElement = <Secrets {...this.props} />;
+        break;
+    }
+
+    return (
+      <div style={styles.wrapper}>
+        <Paper style={styles.menu}>
+          <Menu
+            onChange={this.handleChange}
+            selectedMenuItemStyle={styles.selectedMenuItem}
+            value={this.state.selectedElement}>
+            <MenuItem value={0}>Mounts</MenuItem>
+            <MenuItem value={1}>Secrets</MenuItem>
+          </Menu>
+        </Paper>
+        <div style={styles.content}>
+          {visibleElement}
+        </div>
+      </div>
+    );
+  };
+}

--- a/app/js/components/Secrets.jsx
+++ b/app/js/components/Secrets.jsx
@@ -28,7 +28,6 @@ class Secrets extends React.Component {
   render() {
     return (
       <div>
-        <h2>Read Secrets:</h2>
         <form onSubmit={this.handleSubmit}>
           <TextField
             floatingLabelText="Mount Point"

--- a/app/js/containers/Page.jsx
+++ b/app/js/containers/Page.jsx
@@ -4,8 +4,7 @@ import ReactDOM from 'react-dom';
 import AppBarComposition from '../components/AppBarComposition';
 import Authentication from '../components/Authentication';
 import ConnectionForm from '../components/ConnectionForm';
-import Mounts from '../components/Mounts';
-import Secrets from '../components/Secrets';
+import Interact from '../components/Interact';
 import Unseal from '../components/Unseal';
 
 class Page extends React.Component {
@@ -125,11 +124,9 @@ class Page extends React.Component {
     } else {
       visibleElement = (
         <div>
-          <Mounts
+          <Interact
             getAuths={this.getAuths}
             getMounts={this.getMounts}
-           />
-          <Secrets
             getSecrets={this.getSecrets}/>
         </div>
       );


### PR DESCRIPTION
Previously, in the connected, unseal and authenticated state multple unrelated UI elements were displayed on the same page. (Secrets and Mounts)

This change introduces a menu for choosing which UI to display.

Proposed change:
![capture](https://cloud.githubusercontent.com/assets/4032410/22407560/c18e041a-e636-11e6-8110-92a91ba3316c.png)


