### PR TITLE
List Secret Mounts

### DIFF
--- a/app/js/components/Interact.jsx
+++ b/app/js/components/Interact.jsx
@@ -5,7 +5,7 @@ import MenuItem from 'material-ui/MenuItem';
 import Paper from 'material-ui/Paper';
 
 import Mounts from '../components/Mounts';
-import Secrets from '../components/Secrets';
+import SecretReader from '../components/SecretReader';
 
 const styles = {
   content:{
@@ -44,7 +44,7 @@ export default class Interact extends React.Component {
         visibleElement = <Mounts {...this.props} />;
         break;
       case 1:
-        visibleElement = <Secrets {...this.props} />;
+        visibleElement = <SecretReader {...this.props} />;
         break;
     }
 
@@ -56,7 +56,7 @@ export default class Interact extends React.Component {
             selectedMenuItemStyle={styles.selectedMenuItem}
             value={this.state.selectedElement}>
             <MenuItem value={0}>Mounts</MenuItem>
-            <MenuItem value={1}>Secrets</MenuItem>
+            <MenuItem value={1}>Secret Reader</MenuItem>
           </Menu>
         </Paper>
         <div style={styles.content}>

--- a/app/js/components/Interact.jsx
+++ b/app/js/components/Interact.jsx
@@ -6,6 +6,7 @@ import Paper from 'material-ui/Paper';
 
 import Mounts from '../components/Mounts';
 import SecretReader from '../components/SecretReader';
+import SecretLister from '../components/SecretLister';
 
 const styles = {
   content:{
@@ -46,6 +47,9 @@ export default class Interact extends React.Component {
       case 1:
         visibleElement = <SecretReader {...this.props} />;
         break;
+      case 2:
+        visibleElement = <SecretLister {...this.props} />;
+        break;
     }
 
     return (
@@ -57,6 +61,7 @@ export default class Interact extends React.Component {
             value={this.state.selectedElement}>
             <MenuItem value={0}>Mounts</MenuItem>
             <MenuItem value={1}>Secret Reader</MenuItem>
+            <MenuItem value={2}>Secret Lister</MenuItem>
           </Menu>
         </Paper>
         <div style={styles.content}>

--- a/app/js/components/SecretLister.jsx
+++ b/app/js/components/SecretLister.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import TextField from 'material-ui/TextField';
+import RaisedButton from 'material-ui/RaisedButton';
+
+class SecretLister extends React.Component {
+  state = {
+    path: '',
+    secretMounts: ''
+  }
+
+  handleChange = (event) => {
+    this.setState({path: event.target.value});
+  };
+
+
+  handleSubmit = (event) => {
+    this.props.listSecrets(this.state.path)
+      .then((result) => {
+        this.setState({secretMounts: JSON.stringify(result.data, null, 4)});
+      })
+      .catch((err) => {
+        this.setState({secretMounts: err.toString()});
+      });
+    event.preventDefault();
+  };
+
+  render() {
+    return (
+      <div>
+        <form onSubmit={this.handleSubmit}>
+          <TextField
+            floatingLabelText="Path"
+            hintText="path/to/mountpoint"
+            value={this.state.path}
+            onChange={this.handleChange}/>
+          <RaisedButton
+            type="submit"
+            label="Read"
+            primary={true}/>
+        </form>
+        <pre>
+          <code>
+            {this.state.secretMounts}
+          </code>
+        </pre>
+      </div>
+    );
+  }
+}
+
+export default SecretLister;

--- a/app/js/components/SecretReader.jsx
+++ b/app/js/components/SecretReader.jsx
@@ -4,7 +4,7 @@ import ReactDOM from 'react-dom';
 import TextField from 'material-ui/TextField';
 import RaisedButton from 'material-ui/RaisedButton';
 
-class Secrets extends React.Component {
+class SecretReader extends React.Component {
   state = {
     mountPoint: '',
     secrets: ''
@@ -13,6 +13,7 @@ class Secrets extends React.Component {
   handleChange = (event) => {
     this.setState({mountPoint: event.target.value});
   };
+
 
   handleSubmit = (event) => {
     this.props.getSecrets(this.state.mountPoint)
@@ -31,7 +32,7 @@ class Secrets extends React.Component {
         <form onSubmit={this.handleSubmit}>
           <TextField
             floatingLabelText="Mount Point"
-            hintText="secret/"
+            hintText="secret/foo"
             value={this.state.mountPoint}
             onChange={this.handleChange}/>
           <RaisedButton
@@ -49,4 +50,4 @@ class Secrets extends React.Component {
   }
 }
 
-export default Secrets;
+export default SecretReader;

--- a/app/js/containers/Page.jsx
+++ b/app/js/containers/Page.jsx
@@ -107,6 +107,10 @@ class Page extends React.Component {
     return this.state.vault.read(mountPoint);
   }
 
+  listSecrets = (path) => {
+    return this.state.vault.list(path);
+  }
+
   render = () => {
     let visibleElement = null;
 
@@ -138,7 +142,8 @@ class Page extends React.Component {
           <Interact
             getAuths={this.getAuths}
             getMounts={this.getMounts}
-            getSecrets={this.getSecrets}/>
+            getSecrets={this.getSecrets}
+            listSecrets={this.listSecrets}/>
         </div>
       );
     }


### PR DESCRIPTION
`vault list` provides a way to 'browse' mounted secrets.
This implements that in the most basic way. A user supplied path is used to query the vault for keys mounted at the specified location.
For MVP just the json result is displayed.

Workflow for exploring a Vault.
1. Get mnounted secret backends. Choose one.
2. (this) Enter previous selection as path. A list of keys and directories will be displayed.
	Traverse directories until you find the key you're looking for.
3. Type path and key into Read Secret. Secrets mounted for the key will be displayed

![capture](https://cloud.githubusercontent.com/assets/4032410/22841501/da961d86-ef9f-11e6-8ae3-77c3030338cf.PNG)
