### PR TITLE
Add Ability to Write Secrets

### DIFF
--- a/app/js/components/Interact.jsx
+++ b/app/js/components/Interact.jsx
@@ -7,6 +7,7 @@ import Paper from 'material-ui/Paper';
 import Mounts from '../components/Mounts';
 import SecretReader from '../components/SecretReader';
 import SecretLister from '../components/SecretLister';
+import SecretWriter from '../components/SecretWriter';
 
 const styles = {
   content:{
@@ -50,6 +51,9 @@ export default class Interact extends React.Component {
       case 2:
         visibleElement = <SecretLister {...this.props} />;
         break;
+      case 3:
+        visibleElement = <SecretWriter {...this.props} />;
+        break;
     }
 
     return (
@@ -62,6 +66,7 @@ export default class Interact extends React.Component {
             <MenuItem value={0}>Mounts</MenuItem>
             <MenuItem value={1}>Secret Reader</MenuItem>
             <MenuItem value={2}>Secret Lister</MenuItem>
+            <MenuItem value={3}>Secret Writer</MenuItem>
           </Menu>
         </Paper>
         <div style={styles.content}>

--- a/app/js/components/SecretWriter.jsx
+++ b/app/js/components/SecretWriter.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import TextField from 'material-ui/TextField';
+import RaisedButton from 'material-ui/RaisedButton';
+
+class SecretWriter extends React.Component {
+  state = {
+    path: '',
+    data: '',
+    resultMessage: ''
+  }
+
+  handlePathChange = (event) => {
+    this.setState({path: event.target.value});
+  };
+
+  handleDataChange = (event) => {
+    this.setState({data: event.target.value});
+  };
+
+  handleSubmit = (event) => {
+    this.props.writeSecret(this.state.path, { value: this.state.data })
+      .then((result) => {
+        this.setState({resultMessage: 'success'});
+      })
+      .catch((err) => {
+        this.setState({resultMessage: err.toString()});
+      });
+    event.preventDefault();
+  };
+
+  render() {
+    return (
+      <div>
+        <form onSubmit={this.handleSubmit}>
+          <TextField
+            floatingLabelText="Path"
+            hintText="path/to/<key>"
+            value={this.state.path}
+            onChange={this.handlePathChange}/>
+          <TextField
+            floatingLabelText="Data"
+            hintText="data"
+            value={this.state.data}
+            onChange={this.handleDataChange}/>
+          <RaisedButton
+            type="submit"
+            label="Create"
+            primary={true}/>
+        </form>
+        <pre>
+          <code>
+            {this.state.resultMessage}
+          </code>
+        </pre>
+      </div>
+    );
+  }
+}
+
+export default SecretWriter;

--- a/app/js/containers/Page.jsx
+++ b/app/js/containers/Page.jsx
@@ -143,7 +143,8 @@ class Page extends React.Component {
             getAuths={this.getAuths}
             getMounts={this.getMounts}
             getSecrets={this.getSecrets}
-            listSecrets={this.listSecrets}/>
+            listSecrets={this.listSecrets}
+            writeSecret={this.state.vault.write}/>
         </div>
       );
     }


### PR DESCRIPTION
Adds a UI element on the interaction page to write secrets.
If you have a secret backend mounted at `secret` you would enter
`secret/<key>` in the `Path` texf field and <secret-text> in the `Data`
text field.
Then, to see what you have inserted navigate to the Secret Reader and enter
`secret/<key>`, `<secret-text>` will be returned.

Currently this overwrites existing secrets.