### PR TITLE
Add Status and Health Interact Menu Page

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,6 @@ Feel free to contribute or submit issues as needed.
 6. List Mounted Auth Backends
 7. List Mounted Secrets
 8. Write Secrets
+9. Status and Health
 
 This is my first JS, React and Electron App) Very open to feedback. Please tell me if I'm going about this the wrong way.

--- a/app/js/components/Interact.jsx
+++ b/app/js/components/Interact.jsx
@@ -8,6 +8,7 @@ import Mounts from '../components/Mounts';
 import SecretReader from '../components/SecretReader';
 import SecretLister from '../components/SecretLister';
 import SecretWriter from '../components/SecretWriter';
+import Status from '../components/Status';
 
 const styles = {
   content:{
@@ -54,6 +55,9 @@ export default class Interact extends React.Component {
       case 3:
         visibleElement = <SecretWriter {...this.props} />;
         break;
+      case 4:
+        visibleElement = <Status {...this.props} />;
+        break;
     }
 
     return (
@@ -67,6 +71,7 @@ export default class Interact extends React.Component {
             <MenuItem value={1}>Secret Reader</MenuItem>
             <MenuItem value={2}>Secret Lister</MenuItem>
             <MenuItem value={3}>Secret Writer</MenuItem>
+            <MenuItem value={4}>Status</MenuItem>
           </Menu>
         </Paper>
         <div style={styles.content}>

--- a/app/js/components/Status.jsx
+++ b/app/js/components/Status.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import {Tabs, Tab} from 'material-ui/Tabs';
+
+class Status extends React.Component {
+
+  componentWillMount() {
+    this.loadStatus();
+  }
+
+  state = {
+    status: '',
+    mounts: ''
+  }
+
+  loadStatus = () => {
+    this.props.getStatus()
+      .then((result) => {
+        this.setState({status: JSON.stringify(result, null, 4)});
+      });
+  };
+
+  loadHealth = () => {
+    this.props.getHealth()
+      .then((result) => {
+        this.setState({health: JSON.stringify(result, null, 4)});
+      });
+  };
+
+  render() {
+    return (
+      <Tabs>
+        <Tab
+          label="Status"
+          onActive={this.loadfStatus} >
+            <pre>
+              <code>
+                {this.state.status}
+              </code>
+            </pre>
+        </Tab>
+        <Tab
+          label="Health"
+          onActive={this.loadHealth}>
+          <pre>
+            <code>
+              {this.state.health}
+            </code>
+          </pre>
+        </Tab>
+      </Tabs>
+    );
+  }
+}
+
+export default Status;

--- a/app/js/containers/Page.jsx
+++ b/app/js/containers/Page.jsx
@@ -144,7 +144,9 @@ class Page extends React.Component {
             getMounts={this.getMounts}
             getSecrets={this.getSecrets}
             listSecrets={this.listSecrets}
-            writeSecret={this.state.vault.write}/>
+            writeSecret={this.state.vault.write}
+            getHealth={this.state.vault.health}
+            getStatus={this.state.vault.status}/>
         </div>
       );
     }


### PR DESCRIPTION
Adds ability for authenticated users connected to an unsealed Vault to view the Status and Health of the Vault.
![s1](https://cloud.githubusercontent.com/assets/4032410/22959940/21d4e2c0-f308-11e6-9a39-fe37537cb404.png)
![s2](https://cloud.githubusercontent.com/assets/4032410/22959939/21d4dc30-f308-11e6-9e1a-16f1c125e844.png)

