### PR TITLE
Add GitHub Auth Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Feel free to contribute or submit issues as needed.
 2. Authentication Methods
  * Root Token
  * userpass (username and password)
+ * GitHub Token
 3. Seal/Unseal
 4. Read Secrets
 5. List Mounted Secret Backends
@@ -26,4 +27,4 @@ Feel free to contribute or submit issues as needed.
 8. Write Secrets
 9. Status and Health
 
-This is my first JS, React and Electron App) Very open to feedback. Please tell me if I'm going about this the wrong way.
+This is my first JS, React and Electron App. Very open to feedback. Please tell me if I'm going about this the wrong way.

--- a/app/js/components/Authentication.jsx
+++ b/app/js/components/Authentication.jsx
@@ -5,6 +5,7 @@ import {Tabs, Tab} from 'material-ui/Tabs';
 
 import RootTokenAuthentication from './RootTokenAuthentication';
 import UserPassAuthentication from './UserPassAuthentication';
+import GithubAuthentication from './GithubAuthentication';
 
 class Authentication extends React.Component {
 
@@ -16,6 +17,9 @@ class Authentication extends React.Component {
         </Tab>
         <Tab label="Username/Password" >
           <UserPassAuthentication onSubmit={this.props.userPassAutheticationHandler}/>
+        </Tab>
+        <Tab label="GitHub Token" >
+          <GithubAuthentication onSubmit={this.props.githubAuthenticationHandler}/>
         </Tab>
       </Tabs>
     );

--- a/app/js/components/GithubAuthentication.jsx
+++ b/app/js/components/GithubAuthentication.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import TextField from 'material-ui/TextField';
+import RaisedButton from 'material-ui/RaisedButton';
+
+class GithubAuthentication extends React.Component {
+  state = {token: ''};
+
+  handleChange = (event) => {
+    this.setState({token: event.target.value});
+  };
+
+  handleSubmit = (event) => {
+    console.log(this.props);
+    this.props.onSubmit(this.state.token);
+    event.preventDefault();
+  };
+
+  render() {
+    return (
+        <form onSubmit={this.handleSubmit}>
+          <TextField
+            floatingLabelText="Github Token"
+            value={this.state.token}
+            onChange={this.handleChange}/>
+          <RaisedButton
+            type="submit"
+            label="Connect"
+            primary={true}/>
+        </form>
+    );
+  }
+}
+
+export default GithubAuthentication;

--- a/app/js/containers/Page.jsx
+++ b/app/js/containers/Page.jsx
@@ -71,6 +71,11 @@ class Page extends React.Component {
       .then((result) => this.setVaultTokenAndGetStatus(result.auth.client_token));
   };
 
+  handleGithubAuthentication = (token) => {
+    this.state.vault.githubLogin({ token })
+      .then((result) => this.setVaultTokenAndGetStatus(result.auth.client_token));
+  };
+
   setVaultTokenAndGetStatus = (token) => {
     var vault = this.state.vault;
 
@@ -134,6 +139,7 @@ class Page extends React.Component {
         <Authentication
           rootTokenHandler={this.handleRootTokenAuthentication}
           userPassAutheticationHandler={this.handleUserPassAuthentication}
+          githubAuthenticationHandler={this.handleGithubAuthentication}
         />
       );
     } else {


### PR DESCRIPTION
Allows users to authenticate via a GitHub auth token that belongs to a user or organization that is registered in the auth policies on the Vault server.

![c](https://cloud.githubusercontent.com/assets/4032410/23000552/14ba7d6e-f3af-11e6-86c3-44d6ab7ba182.png)


