### PR TITLE
Add Ability to Delete Secrets

### DIFF
--- a/app/js/components/Interact.jsx
+++ b/app/js/components/Interact.jsx
@@ -8,6 +8,7 @@ import Mounts from '../components/Mounts';
 import Policies from '../components/Policies';
 import SecretReader from '../components/SecretReader';
 import SecretLister from '../components/SecretLister';
+import SecretDeleter from '../components/SecretDeleter';
 import SecretWriter from '../components/SecretWriter';
 import Status from '../components/Status';
 
@@ -57,9 +58,12 @@ export default class Interact extends React.Component {
         visibleElement = <SecretWriter {...this.props} />;
         break;
       case 4:
-        visibleElement = <Status {...this.props} />;
+        visibleElement = <SecretDeleter {...this.props} />;
         break;
       case 5:
+        visibleElement = <Status {...this.props} />;
+        break;
+      case 6:
         visibleElement = <Policies {...this.props} />;
         break;
     }
@@ -75,8 +79,9 @@ export default class Interact extends React.Component {
             <MenuItem value={1}>Secret Reader</MenuItem>
             <MenuItem value={2}>Secret Lister</MenuItem>
             <MenuItem value={3}>Secret Writer</MenuItem>
-            <MenuItem value={4}>Status</MenuItem>
-            <MenuItem value={5}>Policies</MenuItem>
+            <MenuItem value={4}>Secret Deleter</MenuItem>
+            <MenuItem value={5}>Status</MenuItem>
+            <MenuItem value={6}>Policies</MenuItem>
           </Menu>
         </Paper>
         <div style={styles.content}>

--- a/app/js/components/SecretDeleter.jsx
+++ b/app/js/components/SecretDeleter.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import TextField from 'material-ui/TextField';
+import RaisedButton from 'material-ui/RaisedButton';
+
+class SecretDeleter extends React.Component {
+  state = {
+    path: '',
+    resultMessage: ''
+  }
+
+  handlePathChange = (event) => {
+    this.setState({path: event.target.value});
+  };
+
+  handleSubmit = (event) => {
+    this.props.deleteSecret(this.state.path)
+      .then((result) => {
+        this.setState({resultMessage: 'success'});
+      })
+      .catch((err) => {
+        this.setState({resultMessage: err.toString()});
+      });
+    event.preventDefault();
+  };
+
+  render() {
+    return (
+      <div>
+        <form onSubmit={this.handleSubmit}>
+          <TextField
+            floatingLabelText="Path"
+            hintText="path/to/<key>"
+            value={this.state.path}
+            onChange={this.handlePathChange}/>
+          <RaisedButton
+            type="submit"
+            label="Delete"
+            primary={true}/>
+        </form>
+        <pre>
+          <code>
+            {this.state.resultMessage}
+          </code>
+        </pre>
+      </div>
+    );
+  }
+}
+
+export default SecretDeleter;

--- a/app/js/containers/Page.jsx
+++ b/app/js/containers/Page.jsx
@@ -151,6 +151,7 @@ class Page extends React.Component {
             getSecrets={this.getSecrets}
             listSecrets={this.listSecrets}
             writeSecret={this.state.vault.write}
+            deleteSecret={this.state.vault.delete}
             getHealth={this.state.vault.health}
             getStatus={this.state.vault.status}
             getPolicies={this.state.vault.policies}/>


### PR DESCRIPTION
Adds a new page whose sole purpose is to delete secrets.
The user supplies the path to the key they would like to delete.
If the delete succeeds, `success` is displayed, otherwise an error message.

![secret_delete](https://cloud.githubusercontent.com/assets/4032410/23080272/1f555954-f51e-11e6-9c8d-c1b04db88647.gif)
