### PR TITLE
Consolidate Secrets UI into a Single Menu Item

### DIFF
--- a/app/js/components/Interact.jsx
+++ b/app/js/components/Interact.jsx
@@ -6,10 +6,7 @@ import Paper from 'material-ui/Paper';
 
 import Mounts from '../components/Mounts';
 import Policies from '../components/Policies';
-import SecretReader from '../components/SecretReader';
-import SecretLister from '../components/SecretLister';
-import SecretDeleter from '../components/SecretDeleter';
-import SecretWriter from '../components/SecretWriter';
+import Secrets from '../components/Secrets'
 import Status from '../components/Status';
 
 const styles = {
@@ -49,21 +46,12 @@ export default class Interact extends React.Component {
         visibleElement = <Mounts {...this.props} />;
         break;
       case 1:
-        visibleElement = <SecretReader {...this.props} />;
+        visibleElement = <Secrets {...this.props} />;
         break;
       case 2:
-        visibleElement = <SecretLister {...this.props} />;
-        break;
-      case 3:
-        visibleElement = <SecretWriter {...this.props} />;
-        break;
-      case 4:
-        visibleElement = <SecretDeleter {...this.props} />;
-        break;
-      case 5:
         visibleElement = <Status {...this.props} />;
         break;
-      case 6:
+      case 3:
         visibleElement = <Policies {...this.props} />;
         break;
     }
@@ -76,12 +64,9 @@ export default class Interact extends React.Component {
             selectedMenuItemStyle={styles.selectedMenuItem}
             value={this.state.selectedElement}>
             <MenuItem value={0}>Mounts</MenuItem>
-            <MenuItem value={1}>Secret Reader</MenuItem>
-            <MenuItem value={2}>Secret Lister</MenuItem>
-            <MenuItem value={3}>Secret Writer</MenuItem>
-            <MenuItem value={4}>Secret Deleter</MenuItem>
-            <MenuItem value={5}>Status</MenuItem>
-            <MenuItem value={6}>Policies</MenuItem>
+            <MenuItem value={1}>Secrets</MenuItem>
+            <MenuItem value={2}>Status</MenuItem>
+            <MenuItem value={3}>Policies</MenuItem>
           </Menu>
         </Paper>
         <div style={styles.content}>

--- a/app/js/components/Secrets.jsx
+++ b/app/js/components/Secrets.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import {Tabs, Tab} from 'material-ui/Tabs';
+
+import SecretLister from '../components/SecretLister';
+import SecretReader from '../components/SecretReader';
+import SecretDeleter from '../components/SecretDeleter';
+import SecretWriter from '../components/SecretWriter';
+
+class Secrets extends React.Component {
+  render() {
+    return (
+      <Tabs>
+        <Tab
+          label="List">
+            <SecretLister {...this.props}/>
+        </Tab>
+        <Tab
+          label="Read">
+            <SecretReader {...this.props}/>
+        </Tab>
+        <Tab
+          label="Write">
+            <SecretWriter {...this.props}/>
+        </Tab>
+        <Tab
+          label="Delete">
+            <SecretDeleter {...this.props}/>
+        </Tab>
+      </Tabs>
+    );
+  }
+}
+
+export default Secrets;


### PR DESCRIPTION
Secret Lister, Reader, Writer and Deleter are now displayed under tabs for a single menu item.
Since these pages are are very  closely related this is more intuitively structured as tabs. 


![capture](https://cloud.githubusercontent.com/assets/4032410/23082630/283705e0-f528-11e6-8d11-6fba7f6eb486.PNG)
