### PR TITLE
Add Abiltiy to 'Sign Out'

### DIFF
--- a/app/js/components/AppBarComposition.jsx
+++ b/app/js/components/AppBarComposition.jsx
@@ -29,7 +29,12 @@ const Status = (props) => (
       Connection
     </Chip>
 
-    <Chip style={styles.chip}>
+    <Chip
+      style={styles.chip}
+      onRequestDelete={
+        props.isAuthenticated
+          ? () => props.handleSignOut()
+          : null}>
       <Avatar icon={<BooleanStatus value={props.isAuthenticated}/>} />
       Authentication
     </Chip>

--- a/app/js/containers/Page.jsx
+++ b/app/js/containers/Page.jsx
@@ -76,6 +76,10 @@ class Page extends React.Component {
       .then((result) => this.setVaultTokenAndGetStatus(result.auth.client_token));
   };
 
+  handleSignOut = () => {
+    this.setVaultTokenAndGetStatus('');
+  };
+
   setVaultTokenAndGetStatus = (token) => {
     var vault = this.state.vault;
 
@@ -165,6 +169,7 @@ class Page extends React.Component {
           isAuthenticated={this.state.isAuthenticated}
           isSealed={this.state.isSealed}
           handleSeal={this.handleSeal}
+          handleSignOut={this.handleSignOut}
         />
         {visibleElement}
       </div>


### PR DESCRIPTION
Behind the scenes this removes the tokent that the authenticated user is using to interact.
This is offered to the user as an `x` on the authentication chip in the app bar.
Upon singing out, the sign in page is displayed.

![capture](https://cloud.githubusercontent.com/assets/4032410/23083065/1a7f29ee-f52a-11e6-93ae-467aa5348baf.PNG)
