### PR TITLE
Add Ability to Disconnect from a Vault

### DIFF
--- a/app/js/components/AppBarComposition.jsx
+++ b/app/js/components/AppBarComposition.jsx
@@ -24,11 +24,15 @@ function BooleanStatus(props) {
 
 const Status = (props) => (
   <div style={styles.wrapper}>
-    <Chip style={styles.chip}>
+    <Chip
+      style={styles.chip}
+      onRequestDelete={
+        props.isConnected
+          ? () => props.handleDisconnect()
+          : null}>
       <Avatar icon={<BooleanStatus value={props.isConnected}/>} />
       Connection
     </Chip>
-
     <Chip
       style={styles.chip}
       onRequestDelete={

--- a/app/js/containers/Page.jsx
+++ b/app/js/containers/Page.jsx
@@ -17,7 +17,7 @@ class Page extends React.Component {
     isSealed: null,
     keyCount: null,
     progress: null,
-    threshold: null,
+    threshold: null
   };
 
   initVault = (url) => {
@@ -42,6 +42,23 @@ class Page extends React.Component {
             });
         })
         .catch(() => reject("Invalid Server"));
+    });
+  };
+
+  disconnectFromVault = () => {
+    this.setState(
+      {
+        vault: null,
+        options: null,
+        isConnected: false,
+        isAuthenticated: false,
+        isSealed: null,
+        keyCount: null,
+        progress: null,
+        threshold: null
+      },
+      () => {
+        this.refreshStatus();
     });
   };
 
@@ -170,6 +187,7 @@ class Page extends React.Component {
           isSealed={this.state.isSealed}
           handleSeal={this.handleSeal}
           handleSignOut={this.handleSignOut}
+          handleDisconnect={this.disconnectFromVault}
         />
         {visibleElement}
       </div>


### PR DESCRIPTION
Adds an `X` in the connection status chip that allows disconnection.
If the user is authenticated the token will also be cleared.

Behind the scenes this wipes out the vault client object.

Automatically kicks the user back to the connection page.

![image](https://cloud.githubusercontent.com/assets/4032410/23083553/3ca3d9fa-f52c-11e6-9f3c-f996bf2b3168.png)
