### PR TITLE
Move node-vault Dependency from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "gulp": "^3.9.1",
     "gulp-jshint": "^2.0.1",
     "jquery": "~>3.1.0",
-    "jshint": "^2.9.3",
-    "node-vault": "~>0.5.1"
+    "jshint": "^2.9.3"
   },
   "dependencies": {
+    "node-vault": "~>0.5.1",
     "material-ui": "^0.17.0",
     "phantom": "^4.0.0",
     "react": "^15.4.2",


### PR DESCRIPTION
`node-vault` is totally a fully qualified production dependency.
This was mistakenly put in `devDependencies`