### PR TITLE
Add Packagers for OSX, Mac & Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 lib
 node_modules
+release_builds

--- a/package.json
+++ b/package.json
@@ -1,18 +1,25 @@
 {
   "name": "VaultGUI",
+  "productName":"VaultGUI",
   "version": "0.1.0",
-  "description": "description",
+  "description": "A cross-platform desktop application for interacting with a Hashicorp Vault.",
   "main": "app.js",
+  "author": "Jon Savage",
+
   "scripts": {
     "start": "babel app/js -d app/lib && electron app.js",
     "test": "gulp",
-    "build": "babel app/js -d app/lib"
+    "build": "babel app/js -d app/lib",
+    "package:mac":"electron-packager . --overwrite --platform=darwin --arch=x64  --prune=true --out=release_builds",
+    "package:windows":"electron-packager . --overwrite --asar=true --platform=win32 --arch=ia32 --out=release_builds --version-string.FileDescription=CE --version-string.ProductName=\"VaultGUI\"",
+    "package:linux" : "electron-packager . --overwrite --platform=linux --arch=x64 --prune=true --out=release_builds"
   },
+
   "repository": {
     "type": "git",
     "url": "git@github.com:jonsavage/VaultGUI.git"
   },
-  "author": "Jon Savage",
+
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-preset-es2015": "^6.18.0",
@@ -25,6 +32,7 @@
     "gulp-jshint": "^2.0.1",
     "jshint": "^2.9.3"
   },
+
   "dependencies": {
     "node-vault": "~>0.5.1",
     "material-ui": "^0.17.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-1": "^6.16.0",
     "bootstrap": "~>3.3.7",
+    "electron-packager": "^8.5.2",
     "electron-prebuilt": "^1.4.13",
     "gulp": "^3.9.1",
     "gulp-jshint": "^2.0.1",


### PR DESCRIPTION
Adds a packager to create Mac, Linux and Windows executables.

Run `npm run package:mac`, `npm run package:linux` and `npm run package:windows` to create an executable for each respective platform.

Note that in order to create a windows package you need to either use a Windows machine or have `wine`
on your path.

Also, these scripts only create the packages, not the installers. Scripts for those are upcoming.