### PR TITLE
Add Ability to Mount and Unmount Generic Secret Backends

### DIFF
--- a/app/js/components/Mounts.jsx
+++ b/app/js/components/Mounts.jsx
@@ -3,15 +3,11 @@ import ReactDOM from 'react-dom';
 
 import {Tabs, Tab} from 'material-ui/Tabs';
 
-class Mounts extends React.Component {
+import SecretBackends from './SecretBackends'
 
-  componentWillMount() {
-    this.loadMounts();
-  }
-
+export default class Mounts extends React.Component {
   state = {
-    auths: '',
-    mounts: ''
+    auths: ''
   }
 
   loadAuths = () => {
@@ -21,24 +17,12 @@ class Mounts extends React.Component {
       });
   };
 
-  loadMounts = () => {
-    this.props.getMounts()
-      .then((result) => {
-        this.setState({mounts: JSON.stringify(result, null, 4)});
-      });
-  };
-
   render() {
     return (
       <Tabs>
         <Tab
-          label="Secret Backends"
-          onActive={this.loadMounts} >
-            <pre>
-              <code>
-                {this.state.mounts}
-              </code>
-            </pre>
+          label="Secret Backends">
+          <SecretBackends {...this.props}/>
         </Tab>
         <Tab
           label="Auth Backends"
@@ -53,5 +37,3 @@ class Mounts extends React.Component {
     );
   }
 }
-
-export default Mounts;

--- a/app/js/components/SecretBackends.jsx
+++ b/app/js/components/SecretBackends.jsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import RaisedButton from 'material-ui/RaisedButton';
+import TextField from 'material-ui/TextField';
+
+
+export default class SecretBackends extends React.Component {
+  state = {
+    path: '',
+    mounts: ''
+  }
+
+  componentWillMount = () => {
+    this.loadMounts();
+  };
+
+  loadMounts = () => {
+    this.props.getMounts()
+      .then((result) => {
+        this.setState({mounts: JSON.stringify(result, null, 4)});
+      });
+  };
+
+  handlePathChange = (event) => {
+    this.setState({path: event.target.value});
+  };
+
+  mountSecretBackend = () => {
+    this.props.mountSecretBackend(this.state.path)
+      .then(() => this.loadMounts())
+      .catch((err) => {
+        console.log(err);
+      });
+  };
+
+  unmountSecretBackend = () => {
+    this.props.unmountSecretBackend(this.state.path)
+    .then(() => this.loadMounts())
+    .catch((err) => {
+      console.log(err);
+    });
+  };
+
+  render() {
+    return (
+      <div>
+          <TextField
+            floatingLabelText="Mount Point"
+            value={this.state.path}
+            onChange={this.handlePathChange}/>
+          <RaisedButton
+            label="Create"
+            primary={true}
+            onTouchTap={this.mountSecretBackend}/>
+          <RaisedButton
+            label="Delete"
+            primary={true}
+            onTouchTap={this.unmountSecretBackend}/>
+        <pre>
+          <code>
+            {this.state.mounts}
+          </code>
+        </pre>
+      </div>
+    );
+  }
+}

--- a/app/js/containers/Page.jsx
+++ b/app/js/containers/Page.jsx
@@ -137,6 +137,14 @@ class Page extends React.Component {
     return this.state.vault.list(path);
   }
 
+  mountSecretBackend = (path) => {
+    return this.state.vault.mount({ mount_point: path, type: 'generic'});
+  }
+
+  unmountSecretBackend = (path) => {
+    return this.state.vault.unmount({ mount_point: path });
+  }
+
   render = () => {
     let visibleElement = null;
 
@@ -171,11 +179,14 @@ class Page extends React.Component {
             getMounts={this.getMounts}
             getSecrets={this.getSecrets}
             listSecrets={this.listSecrets}
+            mountSecretBackend={this.mountSecretBackend}
             writeSecret={this.state.vault.write}
             deleteSecret={this.state.vault.delete}
             getHealth={this.state.vault.health}
             getStatus={this.state.vault.status}
-            getPolicies={this.state.vault.policies}/>
+            getPolicies={this.state.vault.policies}
+            unmountSecretBackend={this.unmountSecretBackend}
+          />
         </div>
       );
     }


### PR DESCRIPTION
Add the ability to add and remove generic secret backends.
Currently, only generic secret backends are supported. This backend type keeps secrets on disk, more info can be found here: https://www.vaultproject.io/docs/secrets/generic/

![capture](https://cloud.githubusercontent.com/assets/4032410/24813745/39146362-1b9d-11e7-8558-f8402a3bba30.PNG)
