### PR TITLE
Add Ability to Lookup Current Authentication Status

### DIFF
--- a/app/js/components/Interact.jsx
+++ b/app/js/components/Interact.jsx
@@ -4,6 +4,7 @@ import Menu from 'material-ui/Menu';
 import MenuItem from 'material-ui/MenuItem';
 import Paper from 'material-ui/Paper';
 
+import LookupSelf from '../components/LookupSelf';
 import Mounts from '../components/Mounts';
 import Policies from '../components/Policies';
 import Secrets from '../components/Secrets'
@@ -55,6 +56,9 @@ export default class Interact extends React.Component {
       case 3:
         visibleElement = <Policies {...this.props} />;
         break;
+      case 4:
+        visibleElement = <LookupSelf {...this.props} />;
+        break;
     }
 
     return (
@@ -68,6 +72,7 @@ export default class Interact extends React.Component {
             <MenuItem value={1}>Secrets</MenuItem>
             <MenuItem value={2}>Status</MenuItem>
             <MenuItem value={3}>Policies</MenuItem>
+            <MenuItem value={4}>Token Status</MenuItem>
           </Menu>
         </Paper>
         <div style={styles.content}>

--- a/app/js/components/LookupSelf.jsx
+++ b/app/js/components/LookupSelf.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+export default class LookupSelf extends React.Component {
+
+  componentWillMount() {
+    this.lookupSelf();
+  }
+
+  state = {
+    self: ''
+  }
+
+  lookupSelf = () => {
+    this.props.tokenLookupSelf()
+      .then((result) => {
+        this.setState({self: JSON.stringify(result, null, 4)});
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  };
+
+  render() {
+    return (
+      <pre>
+        <code>
+          {this.state.self}
+        </code>
+      </pre>
+    );
+  }
+}

--- a/app/js/containers/Page.jsx
+++ b/app/js/containers/Page.jsx
@@ -185,6 +185,7 @@ class Page extends React.Component {
             getHealth={this.state.vault.health}
             getStatus={this.state.vault.status}
             getPolicies={this.state.vault.policies}
+            tokenLookupSelf={this.state.vault.tokenLookupSelf}
             unmountSecretBackend={this.unmountSecretBackend}
           />
         </div>


### PR DESCRIPTION
Uses the `lookup-self` API command to get authentication information.
This will be used to check tokens used for authentication prior to
reporting a successful login.