### PR TITLE
Fix Invalid Root Token Authentication Bug

### DIFF
--- a/app/js/components/RootTokenAuthentication.jsx
+++ b/app/js/components/RootTokenAuthentication.jsx
@@ -1,23 +1,50 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import Snackbar from 'material-ui/Snackbar';
 import TextField from 'material-ui/TextField';
 import RaisedButton from 'material-ui/RaisedButton';
 
-class RootTokenAuthentication extends React.Component {
-  state = {token: ''};
+export default class RootTokenAuthentication extends React.Component {
+  state = {
+    token: '',
+    snackbar: {
+      open: false,
+      message: ''
+    }
+  };
 
   handleChange = (event) => {
     this.setState({token: event.target.value});
   };
 
   handleSubmit = (event) => {
-    this.props.onSubmit(this.state.token);
+    this.props.onSubmit(this.state.token)
+      .then((result) => console.log(result))
+      .catch((err) =>
+        this.setState(
+          {
+            snackbar: {
+              open: true,
+              message: "Invalid Token"
+            }
+          }));
+
     event.preventDefault();
+  };
+
+  handleSnackbarRequestClose = () => {
+    this.setState({
+      snackbar: {
+        open: false,
+        message: ''
+      }
+    });
   };
 
   render() {
     return (
+      <div>
         <form onSubmit={this.handleSubmit}>
           <TextField
             floatingLabelText="Root Token"
@@ -28,8 +55,12 @@ class RootTokenAuthentication extends React.Component {
             label="Connect"
             primary={true}/>
         </form>
+        <Snackbar
+          open={this.state.snackbar.open}
+          message={this.state.snackbar.message}
+          autoHideDuration={4000}
+          onRequestClose={this.handleSnackbarRequestClose}/>
+      </div>
     );
   }
 }
-
-export default RootTokenAuthentication;

--- a/app/js/containers/Page.jsx
+++ b/app/js/containers/Page.jsx
@@ -83,10 +83,8 @@ class Page extends React.Component {
     var vault = this.state.vault;
     vault.token = token;
 
-    vault.tokenLookupSelf()
-      .then((result) => console.log(result))
-      .then(() => this.setVaultTokenAndGetStatus(token))
-      .catch((err) => console.log(err));
+    return vault.tokenLookupSelf()
+      .then(() => this.setVaultTokenAndGetStatus(token));
   };
 
   handleUserPassAuthentication = (username, password) => {

--- a/app/js/containers/Page.jsx
+++ b/app/js/containers/Page.jsx
@@ -80,7 +80,13 @@ class Page extends React.Component {
   };
 
   handleRootTokenAuthentication = (token) => {
-    this.setVaultTokenAndGetStatus(token);
+    var vault = this.state.vault;
+    vault.token = token;
+
+    vault.tokenLookupSelf()
+      .then((result) => console.log(result))
+      .then(() => this.setVaultTokenAndGetStatus(token))
+      .catch((err) => console.log(err));
   };
 
   handleUserPassAuthentication = (username, password) => {
@@ -99,7 +105,6 @@ class Page extends React.Component {
 
   setVaultTokenAndGetStatus = (token) => {
     var vault = this.state.vault;
-
     vault.token = token;
 
     this.setState({vault: vault}, () => {


### PR DESCRIPTION
Previously, no validation was around root token authentication. When a user authenticated with a bad root token they were not notified and continued like normal to the logged in area (since the token was invalid nothing was loaded).
This adds validation and a Snackbar to let the user know the token is bad. 

 